### PR TITLE
Faster version of DepthFirstScanner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.2</version> <!-- allows consuming the new APIs -->
+            <version>2.4-SNAPSHOT</version> <!-- allows consuming the new APIs -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/FastDepthFirstScanner.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/FastDepthFirstScanner.java
@@ -1,0 +1,17 @@
+package org.jenkinsci.plugins.workflow.pipelinegraphanalysis;
+
+import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
+import org.jenkinsci.plugins.workflow.cps.steps.ParallelStep;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
+
+/**
+ * Faster {@link DepthFirstScanner} variant - more specific test means it stores less nodes in its visited HashSet
+ */
+public class FastDepthFirstScanner extends DepthFirstScanner {
+    @Override
+    protected boolean possibleParallelStart(FlowNode f) {
+        return f instanceof StepStartNode && ((StepStartNode) f).getDescriptor() instanceof ParallelStep.DescriptorImpl;
+    }
+
+}


### PR DESCRIPTION
For those cases where taking an extra dependency on PipelineGraphAnalysis is worth having faster iteration. 

Downstream of https://github.com/jenkinsci/workflow-api-plugin/pull/16

Not putting up for review until I have a downstream consumer.
