### PR TITLE
Create a richer status-mapping API for back-compatibility use

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/GenericStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/GenericStatus.java
@@ -26,8 +26,13 @@ package org.jenkinsci.plugins.workflow.pipelinegraphanalysis;
 
 import hudson.model.Result;
 
+import java.util.Map;
+
 /**
  * Statuses of a {@link org.jenkinsci.plugins.workflow.graphanalysis.FlowChunk} in increasing priority order
+ * Note, when adding new statuses you need to add a new {@link org.jenkinsci.plugins.workflow.pipelinegraphanalysis.StatusAndTiming.StatusApiVersion}
+ *  and set the value of {@link StatusAndTiming#CURRENT_API_VERSION} to that,
+ *  and update {@link StatusAndTiming#coerceStatusMap(Map)} to do coercion for new codings to protect core APIs from unknown values
  */
 public enum GenericStatus {
     /**

--- a/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
@@ -79,6 +79,20 @@ public class StatusAndTimingTest {
         return output;
     }
 
+    @Test
+    public void testStatusCoercion() throws Exception {
+        // Test that we don't modify existing statuses
+        for (GenericStatus st : StatusAndTiming.API_V1.getAllowedStatuses()) {
+            Assert.assertEquals(st, StatusAndTiming.coerceStatusApi(st, StatusAndTiming.API_V1));
+        }
+        // Test that we don't modify statuses of the same API versions
+        for (GenericStatus st : StatusAndTiming.API_V2.getAllowedStatuses()) {
+            Assert.assertEquals(st, StatusAndTiming.coerceStatusApi(st, StatusAndTiming.API_V2));
+            Assert.assertTrue(StatusAndTiming.API_V1.getAllowedStatuses().contains(StatusAndTiming.coerceStatusApi(st, StatusAndTiming.API_V1)));
+        }
+        Assert.assertEquals(GenericStatus.IN_PROGRESS, StatusAndTiming.coerceStatusApi(GenericStatus.QUEUED, StatusAndTiming.API_V1));
+    }
+
     // Helper
     static public long doTiming(FlowExecution exec, int firstNodeId, int nodeAfterEndId) throws  IOException {
         long startTime = TimingAction.getStartTime(exec.getNode(Integer.toString(firstNodeId)));


### PR DESCRIPTION
This lets us add new GenericStatus values without forcing APIs expecting older versions to find a proper way to cope with them.  

This is needed because one can't define a consistent rule of what the correct older GenericStatus value is to represent a newer version -- it may be a higher, lower, or oddball mapping.

@abayer What do you think of the idea?  This is a code sketch of the richer solution I'd alluded to in #11