### PR TITLE
Added a licensing definition to the Maven project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,14 @@
         <tag>HEAD</tag>
     </scm>
 
+    <licenses>
+        <license>
+            <name>The MIT license</name>
+            <url>https://github.com/jenkinsci/pipeline-graph-analysis-plugin/raw/master/LICENSE</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
     <properties>
         <jenkins.version>2.7.3</jenkins.version>
         <java.level>7</java.level>

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
 
     <licenses>
         <license>
-            <name>The MIT license</name>
-            <url>https://github.com/jenkinsci/pipeline-graph-analysis-plugin/raw/master/LICENSE</url>
+            <name>MIT license</name>
+            <url>https://opensource.org/licenses/MIT</url>
             <distribution>repo</distribution>
         </license>
     </licenses>


### PR DESCRIPTION
In order to meet the [prerequisites](https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins#HostingPlugins-Prerequisites) of plugin hosting in the Jenkins Organization, I'm adding the licensing definition in the Maven project.

@reviewbybees, What do you think?


