### PR TITLE
Use ABORTED status for the case the error actions exception is FlowInterruptedException or AbortException

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
@@ -210,11 +210,11 @@ public class StatusAndTimingTest {
                 run, null, exec.getNode("2"), exec.getNode("7"), null));
 
         // Start through to failure point
-        assertEquals(GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus2(
+        assertEquals(GenericStatus.ABORTED, StatusAndTiming.computeChunkStatus2(
                 run, null, exec.getNode("2"), exec.getNode("6"), exec.getNode("7")));
 
         // All but first/last node
-        assertEquals(GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus2(
+        assertEquals(GenericStatus.ABORTED, StatusAndTiming.computeChunkStatus2(
                 run, exec.getNode("2"), exec.getNode("3"), exec.getNode("6"), exec.getNode("7")));
 
         // Before failure node
@@ -271,7 +271,7 @@ public class StatusAndTimingTest {
                 run, null, exec.getNode("2"), exec.getNode("14"), null));
 
         // Failing branch
-        assertEquals(GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus2(
+        assertEquals(GenericStatus.ABORTED, StatusAndTiming.computeChunkStatus2(
                 run, exec.getNode("4"), exec.getNode("7"), exec.getNode("10"), exec.getNode("13")));
 
         // Passing branch
@@ -290,11 +290,11 @@ public class StatusAndTimingTest {
         List<String> outputBranchList = new ArrayList<String>(branchStatuses.keySet());
         Collections.sort(outputBranchList);
         Assert.assertArrayEquals(branches, outputBranchList.toArray());
-        assertEquals(GenericStatus.FAILURE, branchStatuses.get("fail"));
+        assertEquals(GenericStatus.ABORTED, branchStatuses.get("fail"));
         assertEquals(GenericStatus.SUCCESS, branchStatuses.get("success"));
 
         // Verify that overall status returns as failure
-        assertEquals(GenericStatus.FAILURE, StatusAndTiming.condenseStatus(branchStatuses.values()));
+        assertEquals(GenericStatus.ABORTED, StatusAndTiming.condenseStatus(branchStatuses.values()));
 
         // Check timing computation for individual branches
         long[] simulatedPauses = {50L, 5L}; // success, fail


### PR DESCRIPTION
For timeouts and input aborts it does not make sense IMHO to set the stage status to FAILURE - ABORTED makes more sense. Also that way https://github.com/jenkinsci/pipeline-stage-view-plugin/blob/47101e971da4d16a08a4a427c3d72f92cec8ff53/ui/src/main/js/view/templates/pipeline-staged.hbs#L83 is shown correctly for scenarios like

```
stage('Build') { }     
try{ 
    stage('Deploy to TEST') { 
        input "Deploy to TEST?"
    }
} catch(err) { echo "Deployment skipped and stage view box is shown as aborted" }
stage('Other actions') {
    echo "other steps can follow here regardless if the deployment was triggered or aborted"
} 
```
With the PR you get the following (which is the correct behaviour I think):
![image](https://user-images.githubusercontent.com/2581491/48118406-7447ad80-e26c-11e8-8a1b-36b5e14b603f.png)
![image](https://user-images.githubusercontent.com/2581491/48118578-f637d680-e26c-11e8-9286-666bc9c3820a.png)

@svanoort WDYT? (I tried to open a JIRA issue but that does not seem to work currently)