### PR TITLE
Only FlowInterruptedException, not AbortException, should be mapped to ABORTED

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
@@ -307,7 +307,7 @@ public class StatusAndTiming {
             ErrorAction afterError = after.getError();
             if(afterError != null) {
                 Throwable rootCause = afterError.getError();
-                if(rootCause instanceof FlowInterruptedException || rootCause instanceof hudson.AbortException) {
+                if (rootCause instanceof FlowInterruptedException) {
                     return GenericStatus.ABORTED;
                 } else {
                     return GenericStatus.FAILURE;

--- a/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
@@ -210,11 +210,11 @@ public class StatusAndTimingTest {
                 run, null, exec.getNode("2"), exec.getNode("7"), null));
 
         // Start through to failure point
-        assertEquals(GenericStatus.ABORTED, StatusAndTiming.computeChunkStatus2(
+        assertEquals(GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus2(
                 run, null, exec.getNode("2"), exec.getNode("6"), exec.getNode("7")));
 
         // All but first/last node
-        assertEquals(GenericStatus.ABORTED, StatusAndTiming.computeChunkStatus2(
+        assertEquals(GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus2(
                 run, exec.getNode("2"), exec.getNode("3"), exec.getNode("6"), exec.getNode("7")));
 
         // Before failure node
@@ -271,7 +271,7 @@ public class StatusAndTimingTest {
                 run, null, exec.getNode("2"), exec.getNode("14"), null));
 
         // Failing branch
-        assertEquals(GenericStatus.ABORTED, StatusAndTiming.computeChunkStatus2(
+        assertEquals(GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus2(
                 run, exec.getNode("4"), exec.getNode("7"), exec.getNode("10"), exec.getNode("13")));
 
         // Passing branch
@@ -290,11 +290,11 @@ public class StatusAndTimingTest {
         List<String> outputBranchList = new ArrayList<String>(branchStatuses.keySet());
         Collections.sort(outputBranchList);
         Assert.assertArrayEquals(branches, outputBranchList.toArray());
-        assertEquals(GenericStatus.ABORTED, branchStatuses.get("fail"));
+        assertEquals(GenericStatus.FAILURE, branchStatuses.get("fail"));
         assertEquals(GenericStatus.SUCCESS, branchStatuses.get("success"));
 
         // Verify that overall status returns as failure
-        assertEquals(GenericStatus.ABORTED, StatusAndTiming.condenseStatus(branchStatuses.values()));
+        assertEquals(GenericStatus.FAILURE, StatusAndTiming.condenseStatus(branchStatuses.values()));
 
         // Check timing computation for individual branches
         long[] simulatedPauses = {50L, 5L}; // success, fail


### PR DESCRIPTION
Reverts one case of #19 which was incorrect. `AbortException` is a failure. It may be a user error and not have a stack trace, but it is still a failure. Whether `input` step should under certain UI conditions throw `FlowInterruptedException` rather than `AbortException` is a separate question.