### PR TITLE
[JENKINS-55255] Don't assume ABORTED for a FlowInterruptedException

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/GenericStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/GenericStatus.java
@@ -73,5 +73,22 @@ public enum GenericStatus {
     /**
      * Not complete: we are waiting for user input to continue (special case of IN_PROGRESS)
      */
-    PAUSED_PENDING_INPUT
+    PAUSED_PENDING_INPUT;
+
+    /**
+     * Create a {@link GenericStatus} from a {@link Result}
+     */
+    public static GenericStatus fromResult(Result result) {
+        if (result == Result.NOT_BUILT) {
+            return GenericStatus.NOT_EXECUTED;
+        } else if (result == Result.ABORTED) {
+            return GenericStatus.ABORTED;
+        } else if (result == Result.FAILURE ) {
+            return GenericStatus.FAILURE;
+        } else if (result == Result.UNSTABLE ) {
+            return GenericStatus.UNSTABLE;
+        } else {
+            return GenericStatus.SUCCESS;
+        }
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
@@ -289,17 +289,7 @@ public class StatusAndTiming {
             } else {
                 // Final chunk on completed build
                 Result r = run.getResult();
-                if (r == Result.NOT_BUILT) {
-                    return GenericStatus.NOT_EXECUTED;
-                } else if (r == Result.ABORTED) {
-                    return GenericStatus.ABORTED;
-                } else if (r == Result.FAILURE ) {
-                    return GenericStatus.FAILURE;
-                } else if (r == Result.UNSTABLE ) {
-                    return GenericStatus.UNSTABLE;
-                } else {
-                    return GenericStatus.SUCCESS;
-                }
+                return GenericStatus.fromResult(r);
             }
         }
         ErrorAction err = lastNode.getError();
@@ -308,7 +298,7 @@ public class StatusAndTiming {
             if(afterError != null) {
                 Throwable rootCause = afterError.getError();
                 if (rootCause instanceof FlowInterruptedException) {
-                    return GenericStatus.ABORTED;
+                    return GenericStatus.fromResult(((FlowInterruptedException) rootCause).getResult());
                 } else {
                     return GenericStatus.FAILURE;
                 }


### PR DESCRIPTION
Proposed fix for [JENKINS-55255](https://issues.jenkins-ci.org/browse/JENKINS-55255).

Instead of always returning `GenerticStatus.ABORTED` when a `FlowInterruptedException` is encountered, return the `GenericStatus`.corresponding to the `FlowInterruptedException`'s underlying `Result`.

@svanoort please take a look when you have a chance.