### PR TITLE
[JENKINS-55255] Fix computation of chunk status for UNSTABLE and FlowInterruptedException cases. Improves JENKINS-39203 for certain use cases.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/GenericStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/GenericStatus.java
@@ -87,8 +87,10 @@ public enum GenericStatus {
             return GenericStatus.FAILURE;
         } else if (result == Result.UNSTABLE ) {
             return GenericStatus.UNSTABLE;
-        } else {
+        } else if (result == Result.SUCCESS ) {
             return GenericStatus.SUCCESS;
+        } else {
+            return GenericStatus.NOT_EXECUTED;
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/GenericStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/GenericStatus.java
@@ -73,5 +73,22 @@ public enum GenericStatus {
     /**
      * Not complete: we are waiting for user input to continue (special case of IN_PROGRESS)
      */
-    PAUSED_PENDING_INPUT
+    PAUSED_PENDING_INPUT;
+
+    /**
+     * Create a {@link GenericStatus} from a {@link Result}
+     */
+    public static GenericStatus fromResult(Result result) {
+        if (result == Result.NOT_BUILT) {
+            return GenericStatus.NOT_EXECUTED;
+        } else if (result == Result.ABORTED) {
+            return GenericStatus.ABORTED;
+        } else if (result == Result.FAILURE ) {
+            return GenericStatus.FAILURE;
+        } else if (result == Result.UNSTABLE ) {
+            return GenericStatus.UNSTABLE;
+        } else {
+            return GenericStatus.SUCCESS;
+        }
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
@@ -309,7 +309,7 @@ public class StatusAndTiming {
         }
 
         // Previous chunk before end. If flow continued beyond this, it didn't fail.
-        return (run.getResult() == Result.UNSTABLE) ? GenericStatus.UNSTABLE : GenericStatus.SUCCESS;
+        return GenericStatus.SUCCESS;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
@@ -289,17 +289,7 @@ public class StatusAndTiming {
             } else {
                 // Final chunk on completed build
                 Result r = run.getResult();
-                if (r == Result.NOT_BUILT) {
-                    return GenericStatus.NOT_EXECUTED;
-                } else if (r == Result.ABORTED) {
-                    return GenericStatus.ABORTED;
-                } else if (r == Result.FAILURE ) {
-                    return GenericStatus.FAILURE;
-                } else if (r == Result.UNSTABLE ) {
-                    return GenericStatus.UNSTABLE;
-                } else {
-                    return GenericStatus.SUCCESS;
-                }
+                return GenericStatus.fromResult(r);
             }
         }
         ErrorAction err = lastNode.getError();
@@ -308,7 +298,7 @@ public class StatusAndTiming {
             if(afterError != null) {
                 Throwable rootCause = afterError.getError();
                 if (rootCause instanceof FlowInterruptedException) {
-                    return GenericStatus.ABORTED;
+                    return GenericStatus.fromResult(((FlowInterruptedException) rootCause).getResult());
                 } else {
                     return GenericStatus.FAILURE;
                 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
@@ -157,7 +157,7 @@ public class StatusAndTimingTest {
         // Custom unstable status
         run.setResult(Result.UNSTABLE);
         status = StatusAndTiming.computeChunkStatus2(run, null, n[0], n[1], n[2]);
-        assertEquals(GenericStatus.UNSTABLE, status);
+        assertEquals(GenericStatus.SUCCESS, status);
 
         // Failure should assume last chunk ran is where failure happened
         run.setResult(Result.FAILURE);


### PR DESCRIPTION
 [JENKINS-39203](https://issues.jenkins-ci.org/browse/JENKINS-39203)
This change allows scripted pipeline users to set a stage result by throwing a `FlowInterruptedException` within that stage. The exception must be caught outside the stage if the user intends for the pipeline to continue on. Currently `StatusAndTiming#computeChunkStatus2` returns `GenericStatus.UNSTABLE` if the current run has a `Result.UNSTABLE` result and no other conditions are met when determing the chunk status. Instead, allow a `FlowInterruptedException` to set a non `Result.SUCCESS` result and just return `GenericStatus.SUCCESS` if no other conditions are met.

[JENKINS-55255](https://issues.jenkins-ci.org/browse/JENKINS-55255).
Instead of always returning GenerticStatus.ABORTED when a FlowInterruptedException is encountered, return the GenericStatus.corresponding to the FlowInterruptedException's underlying Result.