### PR TITLE
[JENKINS-55255] Fix status computation for FlowInterruptedExceptions with a non-aborted result

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/GenericStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/GenericStatus.java
@@ -87,8 +87,10 @@ public enum GenericStatus {
             return GenericStatus.FAILURE;
         } else if (result == Result.UNSTABLE ) {
             return GenericStatus.UNSTABLE;
-        } else {
+        } else if (result == Result.SUCCESS ) {
             return GenericStatus.SUCCESS;
+        } else {
+            return GenericStatus.NOT_EXECUTED;
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/GenericStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/GenericStatus.java
@@ -73,5 +73,22 @@ public enum GenericStatus {
     /**
      * Not complete: we are waiting for user input to continue (special case of IN_PROGRESS)
      */
-    PAUSED_PENDING_INPUT
+    PAUSED_PENDING_INPUT;
+
+    /**
+     * Create a {@link GenericStatus} from a {@link Result}
+     */
+    public static GenericStatus fromResult(Result result) {
+        if (result == Result.NOT_BUILT) {
+            return GenericStatus.NOT_EXECUTED;
+        } else if (result == Result.ABORTED) {
+            return GenericStatus.ABORTED;
+        } else if (result == Result.FAILURE ) {
+            return GenericStatus.FAILURE;
+        } else if (result == Result.UNSTABLE ) {
+            return GenericStatus.UNSTABLE;
+        } else {
+            return GenericStatus.SUCCESS;
+        }
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
@@ -309,7 +309,7 @@ public class StatusAndTiming {
         }
 
         // Previous chunk before end. If flow continued beyond this, it didn't fail.
-        return (run.getResult() == Result.UNSTABLE) ? GenericStatus.UNSTABLE : GenericStatus.SUCCESS;
+        return GenericStatus.SUCCESS;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
@@ -309,7 +309,7 @@ public class StatusAndTiming {
         }
 
         // Previous chunk before end. If flow continued beyond this, it didn't fail.
-        return GenericStatus.SUCCESS;
+        return (run.getResult() == Result.UNSTABLE) ? GenericStatus.UNSTABLE : GenericStatus.SUCCESS;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
@@ -289,17 +289,7 @@ public class StatusAndTiming {
             } else {
                 // Final chunk on completed build
                 Result r = run.getResult();
-                if (r == Result.NOT_BUILT) {
-                    return GenericStatus.NOT_EXECUTED;
-                } else if (r == Result.ABORTED) {
-                    return GenericStatus.ABORTED;
-                } else if (r == Result.FAILURE ) {
-                    return GenericStatus.FAILURE;
-                } else if (r == Result.UNSTABLE ) {
-                    return GenericStatus.UNSTABLE;
-                } else {
-                    return GenericStatus.SUCCESS;
-                }
+                return GenericStatus.fromResult(r);
             }
         }
         ErrorAction err = lastNode.getError();
@@ -308,7 +298,7 @@ public class StatusAndTiming {
             if(afterError != null) {
                 Throwable rootCause = afterError.getError();
                 if (rootCause instanceof FlowInterruptedException) {
-                    return GenericStatus.ABORTED;
+                    return GenericStatus.fromResult(((FlowInterruptedException) rootCause).getResult());
                 } else {
                     return GenericStatus.FAILURE;
                 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
@@ -157,7 +157,7 @@ public class StatusAndTimingTest {
         // Custom unstable status
         run.setResult(Result.UNSTABLE);
         status = StatusAndTiming.computeChunkStatus2(run, null, n[0], n[1], n[2]);
-        assertEquals(GenericStatus.UNSTABLE, status);
+        assertEquals(GenericStatus.SUCCESS, status);
 
         // Failure should assume last chunk ran is where failure happened
         run.setResult(Result.FAILURE);

--- a/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
@@ -157,7 +157,7 @@ public class StatusAndTimingTest {
         // Custom unstable status
         run.setResult(Result.UNSTABLE);
         status = StatusAndTiming.computeChunkStatus2(run, null, n[0], n[1], n[2]);
-        assertEquals(GenericStatus.SUCCESS, status);
+        assertEquals(GenericStatus.UNSTABLE, status);
 
         // Failure should assume last chunk ran is where failure happened
         run.setResult(Result.FAILURE);


### PR DESCRIPTION
See [JENKINS-55255](https://issues.jenkins-ci.org/browse/JENKINS-55255). Replaces #22 by reverting the part of that PR related to JENKINS-39023 for the reasons described in https://github.com/jenkinsci/pipeline-graph-analysis-plugin/pull/22#discussion_r274511528.

CC @stuartrowe