### PR TITLE
[JENKINS-43292]  Fix visualization of parallel steps with aborted and failed branches

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.0-beta-7</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,8 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
-        <workflow-api.version>2.33</workflow-api.version>
-        <workflow-support.version>3.2</workflow-support.version>
+        <workflow-api.version>2.34-rc889.401891b554d9</workflow-api.version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/89 -->
+        <workflow-support.version>3.3-SNAPSHOT</workflow-support.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.15</version>
+        <version>3.42</version>
         <relativePath />
     </parent>
 
@@ -33,10 +33,10 @@
     </licenses>
 
     <properties>
-        <jenkins.version>2.7.3</jenkins.version>
-        <java.level>7</java.level>
-        <jackson.version>2.4.0</jackson.version>
-        <workflow-api.version>2.22</workflow-api.version>
+        <jenkins.version>2.138.4</jenkins.version>
+        <java.level>8</java.level>
+        <workflow-api.version>2.33</workflow-api.version>
+        <workflow-support.version>3.2</workflow-support.version>
     </properties>
 
     <repositories>
@@ -56,18 +56,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.11</version>
+            <version>2.32</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
             <version>${workflow-api.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>scm-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -75,12 +69,6 @@
             <version>${workflow-api.version}</version>
             <scope>test</scope>
             <classifier>tests</classifier>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>scm-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -90,46 +78,76 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.9</version>
+            <version>1.17</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.14</version>
+            <version>2.19</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.3</version>
+            <version>2.15</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.41</version>
+            <version>2.65</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-stage-step</artifactId>
-            <version>2.2</version>
+            <version>2.3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.14</version>
+            <version>${workflow-support.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+            <version>2.2.7</version>
+        </dependency>
+        <!-- Test scope dependencies -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-scm-step</artifactId>
+            <version>2.7</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.14</version>
+            <version>${workflow-support.version}</version>
             <scope>test</scope>
             <classifier>tests</classifier>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-durable-task-step</artifactId>
+            <artifactId>workflow-cps-global-lib</artifactId>
             <version>2.13</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>2.28</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git-client</artifactId>
+            <version>2.7.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>credentials</artifactId>
+          <version>2.1.18</version>
+          <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
@@ -140,34 +158,14 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mailer</artifactId>
-            <version>1.18</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-multibranch</artifactId>
-            <version>2.9.2</version>
+            <version>1.20</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-model-definition</artifactId>
-            <version>1.2.6</version>
+            <version>1.3.7</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>scm-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>credentials</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>pipeline-graph-analysis</artifactId>
-    <version>1.10-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Pipeline Graph Analysis Plugin</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Graph+Analysis+Plugin</url>
@@ -21,7 +21,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin/</url>
-        <tag>HEAD</tag>
+        <tag>${scmTag}</tag>
     </scm>
 
     <licenses>
@@ -33,6 +33,8 @@
     </licenses>
 
     <properties>
+        <revision>1.10</revision>
+        <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
         <workflow-api.version>2.33</workflow-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
         <workflow-api.version>2.34-rc889.401891b554d9</workflow-api.version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/89 -->
-        <workflow-support.version>3.3-SNAPSHOT</workflow-support.version>
+        <workflow-support.version>3.2</workflow-support.version>
     </properties>
 
     <repositories>

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
@@ -294,17 +294,11 @@ public class StatusAndTiming {
         }
         ErrorAction err = lastNode.getError();
         if (err != null) {
-            ErrorAction afterError = after.getError();
-            if(afterError != null) {
-                Throwable rootCause = afterError.getError();
-                if (rootCause instanceof FlowInterruptedException) {
-                    return GenericStatus.fromResult(((FlowInterruptedException) rootCause).getResult());
-                } else {
-                    return GenericStatus.FAILURE;
-                }
+            Throwable rootCause = err.getError();
+            if (rootCause instanceof FlowInterruptedException) {
+                return GenericStatus.fromResult(((FlowInterruptedException) rootCause).getResult());
             } else {
-                // If next node lacks an ErrorAction, the error was caught in a catch block
-                return GenericStatus.SUCCESS;
+                return GenericStatus.FAILURE;
             }
         }
 


### PR DESCRIPTION
See [JENKINS-43292](https://issues.jenkins-ci.org/browse/JENKINS-43292).

Before this change, non-successful branches in `parallel` steps would always be visualized in Blue Ocean as if they failed, even if they were actually aborted (which can happen when using `failFast: true`). This is confusing, and it caused the aborted branches to be focused and expanded instead of the failed branches, making it hard to determine which branch failed and which branch was aborted.

The reason the visualization used to be incorrect is that for parallel branches, Blue Ocean calls `computeChunkStatus2(before: parallelStartNode, firstNode: parallelBranchStartNode, lastNode: parallelBranchEndNode, after: parallelEndNode)`. In the event that both `parallelBranchEndNode` and `parallelEndNode` have an `ErrorAction`, the `ErrorAction` on the `parallelEndNode` was being used to determine the status, which is incorrect if the branch aborted but the overall parallel step failed. 

The newly added test `parallelFailFast` fails before the change, and the basic test `parallel` passes before and after the change. Both tests use a new `StandardChunkVisitor` to visit parallel branches in a way similar to what is done by Blue Ocean.

For stages, Blue Ocean calls `computeChunkStatus2(before: stageStartNode, firstNode: stageBodyStartNode, lastNode: stageBodyEndNode, after: stageEndNode)`. I am not aware of any way for there to be a different `ErrorAction` on the `stageBodyEndNode` than the `stageEndNode`, so the new code should be identical to the old code for stages. The newly added test `catchOutsideFailingStage` returns the same result before and after the change.

This PR also updates dependencies and incrementalifies the plugin, and requires a version of workflow-api including https://github.com/jenkinsci/workflow-api-plugin/pull/89.

Example Pipeline:

```
parallel failFast: true,
  aborts: {
    sleep 5
  },
  fails: {
    sleep 1
    error('oops')
  },
    succeeds: {
    echo 'success'
  }
```
Before:
<img width="230" alt="Screen Shot 2019-04-16 at 15 19 35" src="https://user-images.githubusercontent.com/1068968/56237874-10b37e80-605b-11e9-98f2-f83be382c3d0.png">

After:
<img width="232" alt="Screen Shot 2019-04-16 at 15 17 15" src="https://user-images.githubusercontent.com/1068968/56237842-fd081800-605a-11e9-8a83-2b08ceaa48fb.png">
