### PR TITLE
[JENKINS-39203] Only show blocks containing a WarningAction as unstable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
-        <workflow-api.version>2.34-rc895.9a08467f4ffb</workflow-api.version> <!-- TODO: https://github.com/jenkinsci/workflow-api-plugin/pull/91 -->
+        <workflow-api.version>2.34-rc901.34c79c66fab6</workflow-api.version> <!-- TODO: https://github.com/jenkinsci/workflow-api-plugin/pull/91 -->
         <workflow-support.version>3.2</workflow-support.version>
     </properties>
 
@@ -90,7 +90,7 @@
         <dependency>
            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.16-rc702.1c79899fca89</version> <!-- TODO: https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/83 -->
+            <version>2.16-rc706.6b7969f3f2b7</version> <!-- TODO: https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/83 -->
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
-        <workflow-api.version>2.34-rc889.401891b554d9</workflow-api.version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/89 -->
+        <workflow-api.version>2.34-20190418.192123-1</workflow-api.version> <!-- https://github.com/jenkinsci/workflow-api-plugin/pull/91 -->
         <workflow-support.version>3.2</workflow-support.version>
     </properties>
 
@@ -88,9 +88,9 @@
             <version>2.19</version>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+           <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.15</version>
+            <version>2.16-20190418.193335-1</version> <!-- TODO: https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/83 -->
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
-        <workflow-api.version>2.34-rc893.b179faa50943</workflow-api.version> <!-- https://github.com/jenkinsci/workflow-api-plugin/pull/91 -->
+        <workflow-api.version>2.34-rc895.9a08467f4ffb</workflow-api.version> <!-- TODO: https://github.com/jenkinsci/workflow-api-plugin/pull/91 -->
         <workflow-support.version>3.2</workflow-support.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
-        <workflow-api.version>2.34-20190418.192123-1</workflow-api.version> <!-- https://github.com/jenkinsci/workflow-api-plugin/pull/91 -->
+        <workflow-api.version>2.34-rc893.b179faa50943</workflow-api.version> <!-- https://github.com/jenkinsci/workflow-api-plugin/pull/91 -->
         <workflow-support.version>3.2</workflow-support.version>
     </properties>
 
@@ -90,7 +90,7 @@
         <dependency>
            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.16-20190418.193335-1</version> <!-- TODO: https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/83 -->
+            <version>2.16-rc702.1c79899fca89</version> <!-- TODO: https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/83 -->
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
-        <workflow-api.version>2.34-rc901.34c79c66fab6</workflow-api.version> <!-- TODO: https://github.com/jenkinsci/workflow-api-plugin/pull/91 -->
+        <workflow-api.version>2.34</workflow-api.version>
         <workflow-support.version>3.2</workflow-support.version>
     </properties>
 
@@ -90,7 +90,7 @@
         <dependency>
            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.16-rc706.6b7969f3f2b7</version> <!-- TODO: https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/83 -->
+            <version>2.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
@@ -316,9 +316,7 @@ public class StatusAndTiming {
         FlowNode found = new DepthFirstScanner().findFirstMatch(
                 Collections.singletonList(end),
                 Collections.singletonList(start),
-                tempNode -> {
-                    return start.getId().equals(tempNode.getEnclosingId()) && tempNode.getPersistentAction(WarningAction.class) != null;
-                });
+                tempNode -> tempNode.getPersistentAction(WarningAction.class) != null);
         if (found != null) {
             return found.getPersistentAction(WarningAction.class);
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
@@ -29,6 +29,7 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Sets;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Action;
 import hudson.model.Result;
 import org.apache.commons.lang.StringUtils;
@@ -313,7 +314,13 @@ public class StatusAndTiming {
         return GenericStatus.SUCCESS;
     }
 
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Non-final for access from the Groovy script console")
+    public static boolean DISABLE_WARNING_ACTION_LOOKUP = Boolean.getBoolean(StatusAndTiming.class.getName() + ".DISABLE_WARNING_ACTION_LOOKUP");
+
     private static @CheckForNull WarningAction findWarningBetween(@Nonnull FlowNode start, @Nonnull FlowNode end) {
+        if (DISABLE_WARNING_ACTION_LOOKUP) {
+            return null;
+        }
         // TODO: Cache the result?
         DepthFirstScanner scanner = new DepthFirstScanner();
         if (!scanner.setup(end, Collections.singletonList(start))) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
@@ -306,7 +306,7 @@ public class StatusAndTiming {
         }
         WarningAction warning = findWarningBetween(firstNode, lastNode);
         if (warning != null) {
-            return GenericStatus.UNSTABLE;
+            return GenericStatus.fromResult(warning.getResult());
         }
 
         // Previous chunk before end. If flow continued beyond this, it didn't fail.
@@ -322,7 +322,7 @@ public class StatusAndTiming {
         return StreamSupport.stream(scanner.spliterator(), false)
                 .map(node -> node.getPersistentAction(WarningAction.class))
                 .filter(Objects::nonNull)
-                .findFirst()
+                .max(Comparator.comparing(warning -> warning.getResult().ordinal))
                 .orElse(null);
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
@@ -29,7 +29,9 @@ import hudson.model.Result;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.slaves.DumbSlave;
 import org.apache.commons.lang.SystemUtils;
+import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.actions.QueueItemAction;
+import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
 import org.jenkinsci.plugins.workflow.actions.TimingAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
@@ -58,13 +60,19 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
+import org.junit.Ignore;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class StatusAndTimingTest {
@@ -745,22 +753,11 @@ public class StatusAndTimingTest {
                 false));
 
         WorkflowRun build = j.assertBuildStatusSuccess(job.scheduleBuild2(0));
-
-        List<MemoryFlowChunk> stages = getStages(build.getExecution());
-
-        Assert.assertEquals(3, stages.size());
-
-        MemoryFlowChunk chunkTests = stages.get(0);
-        Assert.assertEquals("Run Tests", chunkTests.getFirstNode().getDisplayName());
-        Assert.assertEquals(GenericStatus.SUCCESS, StatusAndTiming.computeChunkStatus2(build, chunkTests));
-
-        MemoryFlowChunk chunkWindows = stages.get(1);
-        Assert.assertEquals("Test on Windows", chunkWindows.getFirstNode().getDisplayName());
-        Assert.assertEquals(GenericStatus.NOT_EXECUTED, StatusAndTiming.computeChunkStatus2(build, chunkWindows));
-
-        MemoryFlowChunk chunkLinux = stages.get(2);
-        Assert.assertEquals("Test on Linux", chunkLinux.getFirstNode().getDisplayName());
-        Assert.assertEquals(GenericStatus.SUCCESS, StatusAndTiming.computeChunkStatus2(build, chunkLinux));
+        StagesAndParallelBranchesVisitor visitor = new StagesAndParallelBranchesVisitor(build);
+        assertEquals(3, visitor.chunks.size());
+        visitor.assertStageOrBranchStatus("Run Tests", GenericStatus.SUCCESS);
+        visitor.assertStageOrBranchStatus("Test on Windows", GenericStatus.NOT_EXECUTED);
+        visitor.assertStageOrBranchStatus("Test on Linux", GenericStatus.SUCCESS);
     }
 
     @Test
@@ -775,28 +772,9 @@ public class StatusAndTimingTest {
                 "  echo('caught error')\n" +
                 "}\n", true));
         WorkflowRun run = j.assertBuildStatusSuccess(job.scheduleBuild2(0));
-        FlowExecution exec = run.getExecution();
-        /**
-         * Node dump follows, format:
-         * [ID]{parent,ids} flowNodeClassName stepDisplayName [st=startId if a block end node]
-         *
-         * [2]{}FlowStartNode Start of Pipeline
-         * [3]{2}StepStartNode Stage : Start
-         * [4]{3}StepStartNode throws-error
-         * [5]{4}StepAtomNode Error signal
-         * [6]{5}StepEndNode Stage : Body : End  [st=4]
-         * [7]{6}StepEndNode Stage : End  [st=3]
-         * [8]{7}StepAtomNode Print Message
-         * [9]{8}FlowEndNode End of Pipeline  [st=2]
-         */
-        List<MemoryFlowChunk> stages = getStages(exec);
-        assertEquals(1, stages.size());
-        MemoryFlowChunk stage = stages.get(0);
-        assertEquals(exec.getNode("3"), stage.getNodeBefore());
-        assertEquals(exec.getNode("4"), stage.getFirstNode());
-        assertEquals(exec.getNode("6"), stage.getLastNode());
-        assertEquals(exec.getNode("7"), stage.getNodeAfter());
-        assertEquals(GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus2(run, stage));
+        StagesAndParallelBranchesVisitor visitor = new StagesAndParallelBranchesVisitor(run);
+        assertEquals(1, visitor.chunks.size());
+        visitor.assertStageOrBranchStatus("throws-error", GenericStatus.FAILURE);
     }
 
     @Test
@@ -816,54 +794,11 @@ public class StatusAndTimingTest {
                 "    echo 'success'" +
                 "  }", true));
         WorkflowRun run = j.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0));
-        FlowExecution exec = run.getExecution();
-        /**
-         * Node dump follows, format:
-         * [ID]{parent,ids} flowNodeClassName stepDisplayName [st=startId if a block end node]
-         *
-         * [2]{}FlowStartNode Start of Pipeline
-         * [3]{2}StepStartNode Execute in parallel : Start
-         * [6]{3}StepStartNode Branch: aborts
-         * [7]{3}StepStartNode Branch: fails
-         * [8]{3}StepStartNode Branch: succeeds
-         * [9]{6}StepAtomNode Sleep
-         * [10]{7}StepAtomNode Sleep
-         * [11]{8}StepAtomNode Print Message
-         * [12]{11}StepEndNode Execute in parallel : Body : End  [st=8]
-         * [13]{10}StepAtomNode Error signal
-         * [14]{13}StepEndNode Execute in parallel : Body : End  [st=7]
-         * [15]{9}StepEndNode Execute in parallel : Body : End  [st=6]
-         * [16]{15,14,12}StepEndNode Execute in parallel : End  [st=3]
-         * [17]{16}FlowEndNode End of Pipeline  [st=2]
-         */
-        List<MemoryFlowChunk> stages = getStages(exec);
-        assertEquals(0, stages.size());
-        List<MemoryFlowChunk> branches = getParallelBranches(exec);
-        assertEquals(3, branches.size());
-        {
-            MemoryFlowChunk succeededBranch = branches.get(0);
-            assertEquals(exec.getNode("3"), succeededBranch.getNodeBefore());
-            assertEquals(exec.getNode("8"), succeededBranch.getFirstNode());
-            assertEquals(exec.getNode("12"), succeededBranch.getLastNode());
-            assertEquals(exec.getNode("16"), succeededBranch.getNodeAfter());
-            assertEquals(GenericStatus.SUCCESS, StatusAndTiming.computeChunkStatus2(run, succeededBranch));
-        }
-        {
-            MemoryFlowChunk failedBranch = branches.get(1);
-            assertEquals(exec.getNode("3"), failedBranch.getNodeBefore());
-            assertEquals(exec.getNode("7"), failedBranch.getFirstNode());
-            assertEquals(exec.getNode("14"), failedBranch.getLastNode());
-            assertEquals(exec.getNode("16"), failedBranch.getNodeAfter());
-            assertEquals(GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus2(run, failedBranch));
-        }
-        {
-            MemoryFlowChunk abortedBranch = branches.get(2);
-            assertEquals(exec.getNode("3"), abortedBranch.getNodeBefore());
-            assertEquals(exec.getNode("6"), abortedBranch.getFirstNode());
-            assertEquals(exec.getNode("15"), abortedBranch.getLastNode());
-            assertEquals(exec.getNode("16"), abortedBranch.getNodeAfter());
-            assertEquals(GenericStatus.ABORTED, StatusAndTiming.computeChunkStatus2(run, abortedBranch));
-        }
+        StagesAndParallelBranchesVisitor visitor = new StagesAndParallelBranchesVisitor(run);
+        assertEquals(3, visitor.chunks.size());
+        visitor.assertStageOrBranchStatus("aborts", GenericStatus.ABORTED);
+        visitor.assertStageOrBranchStatus("fails", GenericStatus.FAILURE);
+        visitor.assertStageOrBranchStatus("succeeds", GenericStatus.SUCCESS);
     }
 
     @Test
@@ -878,42 +813,10 @@ public class StatusAndTimingTest {
                 "  echo('succeeds')" +
                 "}\n", true));
         WorkflowRun run = j.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0));
-        FlowExecution exec = run.getExecution();
-        /**
-         * Node dump follows, format:
-         * [ID]{parent,ids} flowNodeClassName stepDisplayName [st=startId if a block end node]
-         *
-         * [2]{}FlowStartNode Start of Pipeline
-         * [3]{2}StepStartNode Execute in parallel : Start
-         * [5]{3}StepStartNode Branch: fails
-         * [6]{3}StepStartNode Branch: succeeds
-         * [7]{5}StepAtomNode Error signal
-         * [8]{7}StepEndNode Execute in parallel : Body : End  [st=5]
-         * [9]{6}StepAtomNode Print Message
-         * [10]{9}StepEndNode Execute in parallel : Body : End  [st=6]
-         * [11]{8,10}StepEndNode Execute in parallel : End  [st=3]
-         * [12]{11}FlowEndNode End of Pipeline  [st=2]
-         */
-        List<MemoryFlowChunk> stages = getStages(exec);
-        assertEquals(0, stages.size());
-        List<MemoryFlowChunk> branches = getParallelBranches(exec);
-        assertEquals(2, branches.size());
-        {
-            MemoryFlowChunk failedBranch = branches.get(0);
-            assertEquals(exec.getNode("3"), failedBranch.getNodeBefore());
-            assertEquals(exec.getNode("6"), failedBranch.getFirstNode());
-            assertEquals(exec.getNode("10"), failedBranch.getLastNode());
-            assertEquals(exec.getNode("11"), failedBranch.getNodeAfter());
-            assertEquals(GenericStatus.SUCCESS, StatusAndTiming.computeChunkStatus2(run, failedBranch));
-        }
-        {
-            MemoryFlowChunk abortedBranch = branches.get(1);
-            assertEquals(exec.getNode("3"), abortedBranch.getNodeBefore());
-            assertEquals(exec.getNode("5"), abortedBranch.getFirstNode());
-            assertEquals(exec.getNode("8"), abortedBranch.getLastNode());
-            assertEquals(exec.getNode("11"), abortedBranch.getNodeAfter());
-            assertEquals(GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus2(run, abortedBranch));
-        }
+        StagesAndParallelBranchesVisitor visitor = new StagesAndParallelBranchesVisitor(run);
+        assertEquals(2, visitor.chunks.size());
+        visitor.assertStageOrBranchStatus("succeeds", GenericStatus.SUCCESS);
+        visitor.assertStageOrBranchStatus("fails", GenericStatus.FAILURE);
     }
 
     @Test
@@ -934,58 +837,11 @@ public class StatusAndTimingTest {
                 "  error('failure')\n" +
                 "}\n", true));
         WorkflowRun run = j.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0));
-        FlowExecution exec = run.getExecution();
-        /**
-         * Node dump follows, format:
-         * [ID]{parent,ids} flowNodeClassName stepDisplayName [st=startId if a block end node]
-         *
-         * [2]{}FlowStartNode Start of Pipeline
-         * [3]{2}StepStartNode Stage : Start
-         * [4]{3}StepStartNode unstable
-         * [5]{4}StepAtomNode Print Message
-         * [6]{5}StepAtomNode UnstableStep
-         * [7]{6}StepAtomNode Print Message
-         * [8]{7}StepEndNode Stage : Body : End  [st=4]
-         * [9]{8}StepEndNode Stage : End  [st=3]
-         * [10]{9}StepStartNode Stage : Start
-         * [11]{10}StepStartNode success
-         * [12]{11}StepAtomNode Print Message
-         * [13]{12}StepEndNode Stage : Body : End  [st=11]
-         * [14]{13}StepEndNode Stage : End  [st=10]
-         * [15]{14}StepStartNode Stage : Start
-         * [16]{15}StepStartNode failure
-         * [17]{16}StepAtomNode UnstableStep
-         * [18]{17}StepAtomNode Error signal
-         * [19]{18}StepEndNode Stage : Body : End  [st=16]
-         * [20]{19}StepEndNode Stage : End  [st=15]
-         * [21]{20}FlowEndNode End of Pipeline  [st=2]
-         */
-        List<MemoryFlowChunk> stages = getStages(exec);
-        assertEquals(3, stages.size());
-        {
-            MemoryFlowChunk unstable = stages.get(0);
-            assertEquals(exec.getNode("3"), unstable.getNodeBefore());
-            assertEquals(exec.getNode("4"), unstable.getFirstNode());
-            assertEquals(exec.getNode("8"), unstable.getLastNode());
-            assertEquals(exec.getNode("9"), unstable.getNodeAfter());
-            assertEquals(GenericStatus.UNSTABLE, StatusAndTiming.computeChunkStatus2(run, unstable));
-        }
-        {
-            MemoryFlowChunk success = stages.get(1);
-            assertEquals(exec.getNode("10"), success.getNodeBefore());
-            assertEquals(exec.getNode("11"), success.getFirstNode());
-            assertEquals(exec.getNode("13"), success.getLastNode());
-            assertEquals(exec.getNode("14"), success.getNodeAfter());
-            assertEquals(GenericStatus.SUCCESS, StatusAndTiming.computeChunkStatus2(run, success));
-        }
-        {
-            MemoryFlowChunk failure = stages.get(2);
-            assertEquals(exec.getNode("15"), failure.getNodeBefore());
-            assertEquals(exec.getNode("16"), failure.getFirstNode());
-            assertEquals(exec.getNode("19"), failure.getLastNode());
-            assertEquals(exec.getNode("20"), failure.getNodeAfter());
-            assertEquals(GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus2(run, failure));
-        }
+        StagesAndParallelBranchesVisitor visitor = new StagesAndParallelBranchesVisitor(run);
+        assertEquals(3, visitor.chunks.size());
+        visitor.assertStageOrBranchStatus("unstable", GenericStatus.UNSTABLE);
+        visitor.assertStageOrBranchStatus("success", GenericStatus.SUCCESS);
+        visitor.assertStageOrBranchStatus("failure", GenericStatus.FAILURE);
     }
 
     @Test
@@ -1001,74 +857,95 @@ public class StatusAndTimingTest {
                 "  }\n" +
                 "}\n", true));
         WorkflowRun run = j.assertBuildStatus(Result.UNSTABLE, job.scheduleBuild2(0));
-        FlowExecution exec = run.getExecution();
-        /**
-         * Node dump follows, format:
-         * [ID]{parent,ids} flowNodeClassName stepDisplayName [st=startId if a block end node]
-         *
-         * [2]{}FlowStartNode Start of Pipeline
-         * [3]{2}StepStartNode Stage : Start
-         * [4]{3}StepStartNode unstable
-         * [5]{4}StepStartNode Enforce time limit : Start
-         * [6]{5}StepStartNode Enforce time limit : Body : Start
-         * [7]{6}StepStartNode Enforce time limit : Start
-         * [8]{7}StepStartNode Enforce time limit : Body : Start
-         * [9]{8}StepAtomNode UnstableStep
-         * [10]{9}StepEndNode Enforce time limit : Body : End  [st=8]
-         * [11]{10}StepEndNode Enforce time limit : End  [st=7]
-         * [12]{11}StepEndNode Enforce time limit : Body : End  [st=6]
-         * [13]{12}StepEndNode Enforce time limit : End  [st=5]
-         * [14]{13}StepEndNode Stage : Body : End  [st=4]
-         * [15]{14}StepEndNode Stage : End  [st=3]
-         * [16]{15}FlowEndNode End of Pipeline  [st=2]
-         */
-        List<MemoryFlowChunk> stages = getStages(exec);
-        assertEquals(1, stages.size());
-        {
-            MemoryFlowChunk unstable = stages.get(0);
-            assertEquals(exec.getNode("3"), unstable.getNodeBefore());
-            assertEquals(exec.getNode("4"), unstable.getFirstNode());
-            assertEquals(exec.getNode("14"), unstable.getLastNode());
-            assertEquals(exec.getNode("15"), unstable.getNodeAfter());
-            assertEquals(GenericStatus.UNSTABLE, StatusAndTiming.computeChunkStatus2(run, unstable));
-        }
+        StagesAndParallelBranchesVisitor visitor = new StagesAndParallelBranchesVisitor(run);
+        assertEquals(1, visitor.chunks.size());
+        visitor.assertStageOrBranchStatus("unstable", GenericStatus.UNSTABLE);
     }
 
-    private static List<MemoryFlowChunk> getStages(FlowExecution execution) {
-        StageTest.CollectingChunkVisitor visitor = new StageTest.CollectingChunkVisitor();
-        ForkScanner.visitSimpleChunks(execution.getCurrentHeads(), visitor, new StageChunkFinder());
-        return visitor.getChunks();
-    }
-
-    private static List<MemoryFlowChunk> getParallelBranches(FlowExecution execution) {
-        CollectingParallelBranchesVisitor visitor = new CollectingParallelBranchesVisitor();
-        ForkScanner.visitSimpleChunks(execution.getCurrentHeads(), visitor, new StageChunkFinder());
-        return visitor.getParallelBranches();
+    @Test
+    @Ignore
+    public void nestedStageParentStatus() throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "unstable");
+        job.setDefinition(new CpsFlowDefinition(
+                "stage('parent') {\n" +
+                "  stage('child') {\n" +
+                "    error('oops')\n" +
+                "  }\n" +
+                "}\n", true));
+        WorkflowRun run = j.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0));
+        StagesAndParallelBranchesVisitor visitor = new StagesAndParallelBranchesVisitor(run);
+        assertEquals(2, visitor.chunks.size());
+        // Fails here. The actual status is SUCCESS because the status is computed between the start of
+        // parent and child. See note in StagesAndParallelBranchesVisitor.assertStageOrBranchStatus.
+        visitor.assertStageOrBranchStatus("parent", GenericStatus.FAILURE);
+        visitor.assertStageOrBranchStatus("child", GenericStatus.FAILURE);
     }
 
     /**
-     * Visitor that collects parallel branches into chunks in a way similar to what Blue Ocean does.
-     * This visitor should only be used for pipelines that have finished executing.
+     * Visitor that collects stages and parallel branches into chunks in a way similar to what
+     * Blue Ocean does.
+     *
+     * This visitor should only be used for pipelines which have finished executing and for
+     * which all stage and parallel branch names are unique.
      */
-    private static class CollectingParallelBranchesVisitor extends StandardChunkVisitor {
-        List<MemoryFlowChunk> parallelBranches = new ArrayList<>();
+    private static class StagesAndParallelBranchesVisitor extends StandardChunkVisitor {
+        private final Map<String, MemoryFlowChunk> chunks = new HashMap<>();
+        private final WorkflowRun run;
+
+        public StagesAndParallelBranchesVisitor(WorkflowRun run) {
+            if (run.isBuilding()) {
+                // TODO: This visitor could be made to work for in progress builds with some changes
+                // to how parallel branches are handled.
+                Assert.fail("Cannot find chunks for a run that is still in progress");
+            }
+            this.run = run;
+            ForkScanner.visitSimpleChunks(run.getExecution().getCurrentHeads(), this, new StageChunkFinder());
+        }
 
         /**
-         * For each chunk, {@link MemoryFlowChunk#getNodeBefore()} is the parallel start node (fan-out),
-         * {@link MemoryFlowChunk#getFirstNode()} is the branch start node, {@link MemoryFlowChunk#getLastNode()} is the
-         * branch end node, and {@link MemoryFlowChunk#getNodeAfter()} is the parallel end node (fan-in).
+         * Assert that the computed status for a stage or branch matches the expected status.
          */
-        public List<MemoryFlowChunk> getParallelBranches() {
-            return new ArrayList<>(parallelBranches);
+        public void assertStageOrBranchStatus(String stageOrBranchName, GenericStatus expected) {
+            MemoryFlowChunk chunk = chunks.get(stageOrBranchName);
+            assertThat(chunk.getNodeBefore(), instanceOf(BlockStartNode.class));
+            assertThat(chunk.getFirstNode(), instanceOf(BlockStartNode.class));
+            assertThat("The parent of FirstNode should be NodeBefore",
+                    chunk.getFirstNode().getParents(), equalTo(Collections.singletonList(chunk.getNodeBefore())));
+            if (chunk.getLastNode() instanceof BlockEndNode) {
+                assertThat(chunk.getLastNode(), instanceOf(BlockEndNode.class));
+                assertThat(chunk.getNodeAfter(), instanceOf(BlockEndNode.class));
+                assertThat("A parent of NodeAfter should be LastNode",
+                        chunk.getNodeAfter().getParents(), hasItem(chunk.getLastNode()));
+                assertThat("NodeBefore and NodeAfter should be the start and end node for the same block",
+                        ((BlockStartNode)chunk.getNodeBefore()).getEndNode(), equalTo(chunk.getNodeAfter()));
+                assertThat("FirstNode and LastNode should be the start and end node for the same block",
+                        ((BlockStartNode)chunk.getFirstNode()).getEndNode(), equalTo(chunk.getLastNode()));
+            } else {
+                // Note: Nested stages are not handled correctly by StandardChunkVisitor (see StandardChunkVisitor
+                // Javadoc). handleChunkDone ends up being called with nodeBefore and firstNode for the parent
+                // stage as expected, but lastNode and nodeAfter are the start of the first nested child stage
+                // rather than the end nodes for the parent stage.
+            }
+            assertThat(StatusAndTiming.computeChunkStatus2(run, chunk), equalTo(expected));
+        }
+
+        @Override
+        public void handleChunkDone(MemoryFlowChunk chunk) {
+            LabelAction action = chunk.getFirstNode().getPersistentAction(LabelAction.class);
+            assertThat("Chunk does not appear to be a Stage", action, notNullValue());
+            chunks.put(action.getDisplayName(), chunk);
+            this.chunk = new MemoryFlowChunk();
         }
 
         @Override
         public void parallelBranchEnd(FlowNode parallelStart, FlowNode branchEnd, ForkScanner scanner) {
-            assert branchEnd instanceof BlockEndNode;
+            assertThat(branchEnd, instanceOf(BlockEndNode.class));
             FlowNode branchStart = ((BlockEndNode)branchEnd).getStartNode();
-            assert parallelStart instanceof BlockStartNode;
+            assertThat(parallelStart, instanceOf(BlockStartNode.class));
             FlowNode parallelEnd = ((BlockStartNode)parallelStart).getEndNode();
-            parallelBranches.add(new MemoryFlowChunk(parallelStart, branchStart, branchEnd, parallelEnd));
+            ThreadNameAction action = branchStart.getPersistentAction(ThreadNameAction.class);
+            assertThat("Cannot determine name of parallel branch", action, notNullValue());
+            chunks.put(action.getThreadName(), new MemoryFlowChunk(parallelStart, branchStart, branchEnd, parallelEnd));
         }
     }
 }


### PR DESCRIPTION
See https://github.com/jenkinsci/workflow-api-plugin/pull/91, https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/83, and [JENKINS-39203](https://issues.jenkins-ci.org/browse/JENKINS-39203). (I am intentionally not updating the status of that ticket or assigning it to myself until I am ready to merge/release all relevant changes to avoid giving users premature hope of a fix and so that I have clear answers for what will and won't work and when any fixes will be released.)

This PR uses `WarningAction` to determine when to return `GenericStatus.UNSTABLE` for a chunk. Even if the overall build is unstable, only chunks containing a `WarningAction` will be marked as unstable. Right now, this is done using a depth-first scan through the current block with no caching. It would probably be a good idea to add some form of caching to avoid repeatedly scanning through stages and branches just to check for `WarningAction`.