### PR TITLE
Bump plugin parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Pipeline Graph Analysis Plugin</name>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Graph+Analysis+Plugin</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.42</version>
+        <version>3.54</version>
         <relativePath />
     </parent>
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
@@ -535,6 +535,11 @@ public class StatusAndTimingTest {
 
         status = StatusAndTiming.computeChunkStatus2(run, null, e.getNode("12"), e.getNode("12"), null);
         assertEquals(GenericStatus.PAUSED_PENDING_INPUT, status);
+
+        run.doStop();
+        j.waitForMessage("Sending interrupt signal to process", run);
+        j.waitForCompletion(run);
+        j.assertBuildStatus(Result.ABORTED, run);
     }
 
     @Issue("JENKINS-44981")


### PR DESCRIPTION
Bumps the [plugin parent POM](https://github.com/jenkinsci/plugin-pom) from 3.42 to 3.54.

See [the changelog](https://github.com/jenkinsci/plugin-pom/releases) and the full diff in [the compare view](https://github.com/jenkinsci/plugin-pom/compare/plugin-3.42...plugin-3.54).