### PR TITLE
Adapt to newer deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.19</version>
+        <version>4.31</version>
         <relativePath />
     </parent>
 
@@ -34,7 +34,7 @@
     <properties>
         <revision>1.12</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.222.4</jenkins.version>
+        <jenkins.version>2.303.3</jenkins.version>
         <java.level>8</java.level>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
@@ -56,8 +56,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.222.x</artifactId>
-                <version>831.v9814430e6383</version>
+                <artifactId>bom-2.303.x</artifactId>
+                <version>987.v4ade2e49fe70</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -65,6 +65,11 @@
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
                 <version>20190722</version>
+            </dependency>
+            <dependency> <!-- TODO pending https://github.com/jenkinsci/bom/pull/716 -->
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-durable-task-step</artifactId>
+                <version>1097.veac1aacfbda8</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -79,27 +84,12 @@
             <artifactId>workflow-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-api</artifactId>
-            <scope>test</scope>
-            <classifier>tests</classifier>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-input-step</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-        </dependency>
-        <dependency>
-           <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-basic-steps</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -114,50 +104,16 @@
             <artifactId>workflow-support</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>scm-api</artifactId>
-        </dependency>
-        <!-- Test scope dependencies -->
-        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-scm-step</artifactId>
+            <artifactId>workflow-api</artifactId>
             <scope>test</scope>
+            <classifier>tests</classifier>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
             <scope>test</scope>
             <classifier>tests</classifier>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-cps-global-lib</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-durable-task-step</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>git-client</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>credentials</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>ssh-credentials</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>mailer</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>

--- a/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
@@ -609,10 +609,10 @@ public class StatusAndTimingTest {
         assertEquals(1, items.length);
         assertEquals(job, items[0].task.getOwnerTask());
         assertTrue(Queue.getInstance().cancel(items[0]));
-        j.assertBuildStatus(Result.FAILURE, j.waitForCompletion(b1));
+        j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(b1));
 
         status = StatusAndTiming.computeChunkStatus2(b1, null, execution.getNode("2"), execution.getNode("5"), null);
-        assertEquals(GenericStatus.FAILURE, status);
+        assertEquals(GenericStatus.ABORTED, status);
 
         stepStart = execution.getNode("5");
         assertNotNull(stepStart);


### PR DESCRIPTION
Amending #11. Adapts `StatusAndTimingTest.queuedAndCanceled` to https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/147 as discovered by https://github.com/jenkinsci/bom/pull/716. Generally updating and cleaning up POM.
