### PR TITLE
Removing `org.json:json` dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,11 +59,6 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
-            <dependency>
-                <groupId>org.json</groupId>
-                <artifactId>json</artifactId>
-                <version>20211205</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Added in #31 and bumps proposed e.g. in #114 but does not seem to be necessary any more. Now:

```
+- org.jenkinsci.plugins:pipeline-model-definition:jar:2.2131.vb_9788088fdb_5:test
|  +- org.jenkinsci.plugins:pipeline-model-api:jar:2.2131.vb_9788088fdb_5:test
|  |  +- org.jenkins-ci.plugins:jackson2-api:jar:2.15.1-344.v6eb_55303dc3e:test
|  |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.15.1:test
|  |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.15.1:test
|  |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.15.1:test
|  |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-json-org:jar:2.15.1:test
|  |  |  |  \- org.json:json:jar:20230227:test
```