### PR TITLE
Flake in `StatusAndTimingTest.testInProgress`

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
@@ -355,6 +355,7 @@ public class StatusAndTimingTest {
                 run, 0, exec.getNode("2"), exec.getNode("6"), null);
         assertEquals((double) (currTime - run.getStartTimeInMillis()), (double) tim.getTotalDurationMillis(), 20.0);
         SemaphoreStep.success("wait/1", null);
+        j.waitForCompletion(run);
     }
 
 


### PR DESCRIPTION
https://github.com/jenkinsci/pipeline-graph-analysis-plugin/pull/124/checks?check_run_id=22050632774 and as usual the culprit is also logged:

```
WARNING	o.j.h.t.RemainingActivityListener#onTearDown: Fails #1 still seems to be running, which could break deletion of log files or metadata
```

(Some other cases were fixed in #72.)