### PR TITLE
Increase likelihood of `StatusAndTimingTest#timingTest` to pass

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
@@ -364,7 +364,7 @@ public class StatusAndTimingTest {
         // Problem here: for runs in progress we should be using current time if they're the last run node, aka the in-progress node
         String jobScript = ""+
                 "echo 'first stage'\n" +
-                "parallel 'long' : { sleep 10; }, \n" +
+                "parallel 'long' : { sleep 30; }, \n" +
                 "         'short': { sleep 2; }";
 
         // This must be amateur science fiction because the exposition for the setting goes on FOREVER
@@ -373,7 +373,7 @@ public class StatusAndTimingTest {
         job.setDefinition(new CpsFlowDefinition(jobScript, true));
         WorkflowRun run = job.scheduleBuild2(0).getStartCondition().get();
         try {
-        Thread.sleep(4000);  // We need the short branch to be complete so we know timing should exceed its duration
+        Thread.sleep(12000);  // We need the short branch to be complete so we know timing should exceed its duration
         FlowExecution exec = run.getExecution();
         List<FlowNode> heads = exec.getCurrentHeads();
         assertEquals(GenericStatus.IN_PROGRESS, StatusAndTiming.computeChunkStatus2(


### PR DESCRIPTION
I saw this test fail in BOM on a heavily loaded Kubernetes cluster with

```
java.lang.AssertionError: expected:<SUCCESS> but was:<IN_PROGRESS>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:120)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at org.jenkinsci.plugins.workflow.pipelinegraphanalysis.StatusAndTimingTest.timingTest(StatusAndTimingTest.java:381)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:706)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

This change triples the likelihood this test will pass by waiting three times longer.

### Testing done

`mvn clean verify`

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
