### PR TITLE
fix: stage status in case of retries

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
@@ -302,8 +302,11 @@ public class StatusAndTiming {
             }
         }
         WarningAction warning = findWorstWarningBetween(firstNode, lastNode);
-        if (warning != null) {
-            return GenericStatus.fromResult(warning.getResult());
+        Result result = run.getResult();
+        if (warning != null && result != null) {
+            if(!result.toString().equalsIgnoreCase(GenericStatus.SUCCESS.toString())) {
+                return GenericStatus.fromResult(warning.getResult());
+            }
         }
 
         // Previous chunk before end. If flow continued beyond this, it didn't fail.


### PR DESCRIPTION
When a retry block is used inside a stage and the step failed in first attempt but passed in one of the subsequent attempts, expected stage result is "Success", expected build result is "Success" but the actual stage result is "Failure", actual build result is "Success". Screenshot of this bug is attached below.

<img width="1059" alt="image" src="https://github.com/user-attachments/assets/468ae18f-9b47-479a-aa40-b5fa24aba37d" />

Fix implemented:
While debugging, i noticed that this failure status is returned from WarningAction condition. So, have added another condition to check run result, so that this condition does not return failure when run result is success.

### Testing done
Have tested this change locally with following test cases:
- Successful Stage without retry step
- Failed Stage without retry step
- Successful Stage with retry step
- Failed Stage with retry step

below is the screenshot of stage view of local test execution
<img width="1022" alt="image" src="https://github.com/user-attachments/assets/c47391db-9d1f-4ceb-8ece-61d79e9d3f0b" />
