### PR TITLE
Modify computeChunkTiming to always use the start time of lastNode as the endTime for parallel branches

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
@@ -374,14 +374,10 @@ public class StatusAndTiming {
         verifySameRun(run, firstNode, lastNode, after);
         long endTime = (after != null) ? TimingAction.getStartTime(after) : System.currentTimeMillis();
 
-        // Fudge
-        boolean isLastChunk = after == null || exec.isCurrentHead(lastNode);
-        if (isLastChunk && run.isBuilding()) {
-            if (exec.getCurrentHeads().size() > 1 && lastNode instanceof BlockEndNode blockEndNode) {  // Check to see if all the action is on other branches
-                BlockStartNode start = blockEndNode.getStartNode();
-                if (start.getAction(ThreadNameAction.class) != null) {
-                    endTime = TimingAction.getStartTime(lastNode);  // Completed parallel branch, use the block end time
-                }
+        if (lastNode instanceof BlockEndNode blockEndNode) {
+            BlockStartNode start = blockEndNode.getStartNode();
+            if (start.getAction(ThreadNameAction.class) != null) {
+                endTime = TimingAction.getStartTime(lastNode);  // Completed parallel branch, use the block end time
             }
         }
         // What about null startTime???

--- a/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
@@ -319,13 +319,13 @@ public class StatusAndTimingTest {
         // Passing branch time, 5 ms pause was a present above
         TimingInfo successTiming = branchTimings.get("success");
         assertEquals(50L, successTiming.getPauseDurationMillis());
-        long successRunTime = doTiming(exec, 6, 13);
+        long successRunTime = doTiming(exec, 6, 12);
         assertEquals(successRunTime, successTiming.getTotalDurationMillis());
         assertEquals(TimingAction.getStartTime(exec.getNode("6")), successTiming.getStartTimeMillis());
 
         // Failing branch time, 50 ms pause was a present above
         TimingInfo failTiming = branchTimings.get("fail");
-        long failRunTime = doTiming(exec, 7, 13);
+        long failRunTime = doTiming(exec, 7, 10);
         assertEquals(Math.min(5L, failRunTime), failTiming.getPauseDurationMillis());
         assertEquals(failRunTime, failTiming.getTotalDurationMillis());
         assertEquals(TimingAction.getStartTime(exec.getNode("7")), failTiming.getStartTimeMillis());


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fix for [JENKINS-75640](https://issues.jenkins.io/browse/JENKINS-75640) after discussion on https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/368.

The current implementation of [`StatusAndTiming#computeChunkTiming`](https://github.com/jenkinsci/pipeline-graph-analysis-plugin/blob/baa36bf248c2b42f17a580c6590ff5280a34525a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java#L364-L394) always computes the timing of parallel branches using the start time of closing parallel step node - the start time of the current branch's start node for completed builds. This isn't correct as each branch may take a different amount of time.

This change removes the conditions around using the the start time of branch's end node so that it will be used for both active and complete builds.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

The [StatusAndTimingTest#testBasicParallelFail](https://github.com/jenkinsci/pipeline-graph-analysis-plugin/blob/baa36bf248c2b42f17a580c6590ff5280a34525a/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java#L237-L340) test already has basic validation that branch timings are correct. I've just updated the assert logic so that comparison timing is also computed using the branch's end node instead of the after node.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
